### PR TITLE
docker-compose 対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.60 as base
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.toml
+RUN mkdir src
+
+# docker cacheを効かせるため
+RUN echo "fn main(){}" > src/main.rs
+RUN cargo build --release
+
+COPY ./src ./src
+RUN rm -rf target/release/deps/parse_conf*
+
+FROM base as develop
+COPY test.conf test.conf
+CMD cargo run test.conf
+
+FROM base as build-production
+RUN cargo build --release
+CMD ./target/release/parse-conf test.conf
+
+FROM gcr.io/distroless/cc as production
+COPY --from=build-production /app/target/release/parse-conf /
+COPY test.conf test.conf
+ENTRYPOINT [ "./parse-conf" ]
+CMD ["test.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY Cargo.toml Cargo.toml
 RUN mkdir src
 
 # docker cacheを効かせるため
+# TODO:sccache, mold なんかを使うとbuild速度改善できるかも
 RUN echo "fn main(){}" > src/main.rs
 RUN cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# conf-parse
+# conf-
+conf(ini)ファイルを読み取ってデータ型に格納する
 
 ## 実行
+docker-compose, docker, cargoそれぞれの実行方法は以下の通り
 ```sh
 docker-compose up
 ```
@@ -11,6 +13,6 @@ docker run app
 ```
 ## 開発
 ```sh
-# 引数で読み取るファイルを指定
-cargo run test.conf
+cargo run
+# cargo run test.conf 引数で読み取るファイルを指定する
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # conf-parse
 
+## 実行
+```sh
+docker-compose up
+```
+```sh
+docker build -t app --target production .
+docker run app
+# docker run app test.conf 実行時にファイル指定できる
+```
 ## 開発
 ```sh
 # 引数で読み取るファイルを指定

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-  web:
+  app:
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,9 +118,14 @@ impl TypedValue {
 
 fn main() -> Result<(), Box<(dyn Error + 'static)>> {
     let args: Vec<String> = env::args().collect();
+    let file_path = if args.len() <= 1 {
+        "test.conf"
+    } else {
+        &args[1]
+    };
+    
     let mut config = Ini::new();
-
-    let raw_config = config.load(&args[1])?;
+    let raw_config = config.load(file_path)?;
     let typed_config = TypedConfig::raw_to_typed(raw_config);
     println!("{:#?}", typed_config);
 


### PR DESCRIPTION
fix #2

やったこと
- マルチステージのDockerfile作成
- dockerのキャッシュが効くように前処理
- 最終的にdistrolessのイメージにバイナリを出力。distrolessを使った理由はイメージサイズの削減とセキュリティの観点から
https://github.com/GoogleContainerTools/distroless#why-should-i-use-distroless-images
- entrypoint と cmdを分離することで`docker run` でコマンドを上書きする場合にファイル名を渡すだけで良くなる
- デフォルトのファイル名を設定

気になること
RustにはPath型なるものがあった気がする。。。後回し